### PR TITLE
Fix statement in media license

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -31,7 +31,7 @@ Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)
 Copyright (C) 2022 BuckarooBanzai
 
 You are free to:
-Share — copy and redistribute the material in any medium or format.
+Share — copy and redistribute the material in any medium or format for any purpose, even commercially.
 Adapt — remix, transform, and build upon the material for any purpose, even commercially.
 The licensor cannot revoke these freedoms as long as you follow the license terms.
 


### PR DESCRIPTION
Things added/changed:

- Fix statement in media license.
  - If you see the [original document](https://creativecommons.org/licenses/by-sa/3.0/), you can see that it clearly says `for any purpose, even commercially`. For some reason, that wasn't present in the license text here.
